### PR TITLE
Ikke endre tilordnetEnhet ved oppdatering av Oppgave

### DIFF
--- a/src/main/kotlin/no/nav/syfo/aksessering/api/HentPapirSykmeldingOppgaveRest.kt
+++ b/src/main/kotlin/no/nav/syfo/aksessering/api/HentPapirSykmeldingOppgaveRest.kt
@@ -108,7 +108,7 @@ fun Route.hentPapirSykmeldingManuellOppgave(
                                     manuellOppgaveService = manuellOppgaveService,
                                     loggingMeta = loggingMeta,
                                     oppgaveId = oppgaveId,
-                                    navEnhet = "9999",
+                                    navEnhet = null,
                                     accessToken = accessToken
                                 )
 

--- a/src/main/kotlin/no/nav/syfo/aksessering/api/HentPapirSykmeldingOppgaveRest.kt
+++ b/src/main/kotlin/no/nav/syfo/aksessering/api/HentPapirSykmeldingOppgaveRest.kt
@@ -108,7 +108,6 @@ fun Route.hentPapirSykmeldingManuellOppgave(
                                     manuellOppgaveService = manuellOppgaveService,
                                     loggingMeta = loggingMeta,
                                     oppgaveId = oppgaveId,
-                                    navEnhet = null,
                                     accessToken = accessToken
                                 )
 

--- a/src/main/kotlin/no/nav/syfo/client/OppgaveClient.kt
+++ b/src/main/kotlin/no/nav/syfo/client/OppgaveClient.kt
@@ -126,11 +126,10 @@ class OppgaveClient(
         }
     }
 
-    suspend fun sendOppgaveTilGosys(oppgaveId: Int, msgId: String, tildeltEnhetsnr: String?, tilordnetRessurs: String): Oppgave {
+    suspend fun sendOppgaveTilGosys(oppgaveId: Int, msgId: String, tilordnetRessurs: String): Oppgave {
         val oppgave = hentOppgave(oppgaveId, msgId)
-        val oppdatertOppgave = oppgave.copy(
+        var oppdatertOppgave = oppgave.copy(
             behandlesAvApplikasjon = "FS22",
-            tildeltEnhetsnr = tildeltEnhetsnr,
             tilordnetRessurs = tilordnetRessurs
         )
         return oppdaterOppgave(oppdatertOppgave, msgId)

--- a/src/main/kotlin/no/nav/syfo/client/OppgaveClient.kt
+++ b/src/main/kotlin/no/nav/syfo/client/OppgaveClient.kt
@@ -128,7 +128,7 @@ class OppgaveClient(
 
     suspend fun sendOppgaveTilGosys(oppgaveId: Int, msgId: String, tilordnetRessurs: String): Oppgave {
         val oppgave = hentOppgave(oppgaveId, msgId)
-        var oppdatertOppgave = oppgave.copy(
+        val oppdatertOppgave = oppgave.copy(
             behandlesAvApplikasjon = "FS22",
             tilordnetRessurs = tilordnetRessurs
         )

--- a/src/main/kotlin/no/nav/syfo/client/OppgaveClient.kt
+++ b/src/main/kotlin/no/nav/syfo/client/OppgaveClient.kt
@@ -126,7 +126,7 @@ class OppgaveClient(
         }
     }
 
-    suspend fun sendOppgaveTilGosys(oppgaveId: Int, msgId: String, tildeltEnhetsnr: String, tilordnetRessurs: String): Oppgave {
+    suspend fun sendOppgaveTilGosys(oppgaveId: Int, msgId: String, tildeltEnhetsnr: String?, tilordnetRessurs: String): Oppgave {
         val oppgave = hentOppgave(oppgaveId, msgId)
         val oppdatertOppgave = oppgave.copy(
             behandlesAvApplikasjon = "FS22",

--- a/src/main/kotlin/no/nav/syfo/persistering/HandleSendOppgaveTilGosys.kt
+++ b/src/main/kotlin/no/nav/syfo/persistering/HandleSendOppgaveTilGosys.kt
@@ -13,7 +13,7 @@ suspend fun handleSendOppgaveTilGosys(
     manuellOppgaveService: ManuellOppgaveService,
     loggingMeta: LoggingMeta,
     oppgaveId: Int,
-    navEnhet: String,
+    navEnhet: String?,
     accessToken: String
 ) {
     val veileder = authorizationService.getVeileder(accessToken)

--- a/src/main/kotlin/no/nav/syfo/persistering/HandleSendOppgaveTilGosys.kt
+++ b/src/main/kotlin/no/nav/syfo/persistering/HandleSendOppgaveTilGosys.kt
@@ -13,7 +13,6 @@ suspend fun handleSendOppgaveTilGosys(
     manuellOppgaveService: ManuellOppgaveService,
     loggingMeta: LoggingMeta,
     oppgaveId: Int,
-    navEnhet: String?,
     accessToken: String
 ) {
     val veileder = authorizationService.getVeileder(accessToken)
@@ -23,7 +22,6 @@ suspend fun handleSendOppgaveTilGosys(
     oppgaveClient.sendOppgaveTilGosys(
         oppgaveId = oppgaveId,
         msgId = loggingMeta.msgId,
-        tildeltEnhetsnr = navEnhet,
         tilordnetRessurs = veileder.veilederIdent
     )
     manuellOppgaveService.ferdigstillSmRegistering(oppgaveId)

--- a/src/main/kotlin/no/nav/syfo/persistering/api/SendOppgaveTilGosysRest.kt
+++ b/src/main/kotlin/no/nav/syfo/persistering/api/SendOppgaveTilGosysRest.kt
@@ -43,10 +43,6 @@ fun Route.sendOppgaveTilGosys(
                     log.error("Mangler JWT Bearer token i HTTP header")
                     call.respond(HttpStatusCode.Unauthorized, "Mangler JWT Bearer token i HTTP header")
                 }
-                navEnhet == null -> {
-                    log.error("Mangler X-Nav-Enhet i http header")
-                    call.respond(HttpStatusCode.BadRequest, "Mangler X-Nav-Enhet i HTTP header")
-                }
                 else -> {
 
                     val manuellOppgaveDTOList = manuellOppgaveService.hentManuellOppgaver(oppgaveId)
@@ -66,7 +62,7 @@ fun Route.sendOppgaveTilGosys(
 
                     if (authorizationService.hasAccess(accessToken, pasientFnr)) {
 
-                        handleSendOppgaveTilGosys(authorizationService, oppgaveClient, manuellOppgaveService, loggingMeta, oppgaveId, navEnhet, accessToken)
+                        handleSendOppgaveTilGosys(authorizationService, oppgaveClient, manuellOppgaveService, loggingMeta, oppgaveId, accessToken)
 
                         call.respond(HttpStatusCode.NoContent)
                     } else {

--- a/src/test/kotlin/no/nav/syfo/api/HentPapirSykmeldingManuellOppgaveTest.kt
+++ b/src/test/kotlin/no/nav/syfo/api/HentPapirSykmeldingManuellOppgaveTest.kt
@@ -494,7 +494,7 @@ internal class HentPapirSykmeldingManuellOppgaveTest {
                 }
             }
 
-            coEvery { oppgaveClient.sendOppgaveTilGosys(any(), any(), any(), any()) } returns Oppgave(
+            coEvery { oppgaveClient.sendOppgaveTilGosys(any(), any(), any()) } returns Oppgave(
                 id = 123, versjon = 2,
                 tilordnetRessurs = "",
                 tildeltEnhetsnr = "",
@@ -522,7 +522,7 @@ internal class HentPapirSykmeldingManuellOppgaveTest {
                 response.content shouldEqual "SENT_TO_GOSYS"
             }
 
-            coVerify(exactly = 1) { oppgaveClient.sendOppgaveTilGosys(any(), any(), any(), any()) }
+            coVerify(exactly = 1) { oppgaveClient.sendOppgaveTilGosys(any(), any(), any()) }
         }
     }
 

--- a/src/test/kotlin/no/nav/syfo/api/SendOppgaveTilGosysRestTest.kt
+++ b/src/test/kotlin/no/nav/syfo/api/SendOppgaveTilGosysRestTest.kt
@@ -166,7 +166,7 @@ class SendOppgaveTilGosysRestTest {
 
             coEvery { manuellOppgaveService.hentManuellOppgaver(any()) } returns listOf(manuellOppgaveDTO)
 
-            coEvery { oppgaveClient.sendOppgaveTilGosys(any(), any(), any(), any()) } returns Oppgave(
+            coEvery { oppgaveClient.sendOppgaveTilGosys(any(), any(), any()) } returns Oppgave(
                 id = oppgaveid,
                 versjon = 1,
                 tilordnetRessurs = "",


### PR DESCRIPTION
Bugfix: Ikke endre tilordnetEnhet for oppgaver som skal tilbake til Gosys. Vi har ikke alltid denne informasjonen, og det er heller ikke nødvendig å endre den - samme enhet skal jobbe videre med oppgaven i Gosys også.