### PR TITLE
Bugfix: sett oppgave.beskrivelse til oppgavens opprinnelige beskrivel…

### DIFF
--- a/src/main/kotlin/no/nav/syfo/persistering/HandleOKOppgave.kt
+++ b/src/main/kotlin/no/nav/syfo/persistering/HandleOKOppgave.kt
@@ -59,7 +59,8 @@ suspend fun handleOKOppgave(
             status = OppgaveStatus.FERDIGSTILT,
             tildeltEnhetsnr = navEnhet,
             tilordnetRessurs = veileder.veilederIdent,
-            mappeId = null
+            mappeId = null,
+            beskrivelse = oppgave.beskrivelse
         )
 
         val ferdigstiltOppgave = oppgaveClient.ferdigstillOppgave(ferdigstillOppgave, sykmeldingId)


### PR DESCRIPTION
…se ved ferdigstilling av OK oppgave for å unnge å sende nullverdi